### PR TITLE
CONFIG: updated some configurations, made some cosmetic fixes

### DIFF
--- a/config/configuration.py
+++ b/config/configuration.py
@@ -1,14 +1,19 @@
 import os
+import numpy as np
 from argparse import Namespace
 
 _DEFAULT_TIMESTEPS = 250
+_DEFAULT_V_MIN_MAX = (0.01, 0.1)
 _DEFAULT_RECON_BATCH_SIZE = 5
 _DEFAULT_OUTPUT_DIR_NAME = 'output'
+
+MAGIC_NORMALIZE_MEAN = np.array([-0.229/0.485, -0.224/0.456, -0.255/0.406])
+MAGIC_NORMALIZE_STD = np.array([0.229, 0.224, 0.255])
 
 DIFFUSION_AD_REQUIRED_HPARAMS = [
     'reconstruction_batch_size', 
     'anomaly_map_generator_kwargs', 
-    'anomaly_scorer_kwargs'
+    'anomaly_scorer_kwargs',
     'phase',
     'category',
     'dataset_path',
@@ -26,7 +31,7 @@ DIFFUSION_AD_HPARAMS = Namespace(**{
     'anomaly_scorer_kwargs': {},
     'phase': 'test',
     'category': 'hazelnut',
-    'dataset_path': './extern/mvtec',
+    'dataset_path': os.path.abspath(os.path.join(__file__, '..', '..', 'extern', 'mvtec')),
     'num_epochs': 1,
     'batch_size': 1,
     'load_size': 256,
@@ -38,10 +43,10 @@ DIFFUSION_AD_HPARAMS = Namespace(**{
 CATEGORY_TO_NOISE_TIMESTEPS = {
     'bottle': _DEFAULT_TIMESTEPS,
     'cable': _DEFAULT_TIMESTEPS,
-    'capsule': _DEFAULT_TIMESTEPS,
+    'capsule': 350,
     'carpet': _DEFAULT_TIMESTEPS,
-    'grid': _DEFAULT_TIMESTEPS,
-    'hazelnut': _DEFAULT_TIMESTEPS,
+    'grid': 300,
+    'hazelnut': 250,
     'leather': _DEFAULT_TIMESTEPS,
     'metal_nut': _DEFAULT_TIMESTEPS,
     'pill': _DEFAULT_TIMESTEPS,
@@ -51,4 +56,22 @@ CATEGORY_TO_NOISE_TIMESTEPS = {
     'transistor': _DEFAULT_TIMESTEPS,
     'wood': _DEFAULT_TIMESTEPS,
     'zipper': _DEFAULT_TIMESTEPS
+}
+
+CATEGORY_TO_V_MIN_MAX = {
+    'bottle': _DEFAULT_V_MIN_MAX,
+    'cable': _DEFAULT_V_MIN_MAX,
+    'capsule': (0.04, 0.08),
+    'carpet': _DEFAULT_V_MIN_MAX,
+    'grid': (0.025, 0.09),
+    'hazelnut': (0.02, 0.08),
+    'leather': _DEFAULT_V_MIN_MAX,
+    'metal_nut': _DEFAULT_V_MIN_MAX,
+    'pill': _DEFAULT_V_MIN_MAX,
+    'screw': _DEFAULT_V_MIN_MAX,
+    'tile': _DEFAULT_V_MIN_MAX,
+    'toothbrush': _DEFAULT_V_MIN_MAX,
+    'transistor': _DEFAULT_V_MIN_MAX,
+    'wood': _DEFAULT_V_MIN_MAX,
+    'zipper': _DEFAULT_V_MIN_MAX
 }


### PR DESCRIPTION
- dataset_path is now defined independently like root_output_dir.
- extracted the magic numbers to the configuration.py file.
- hotfix: misplaced ',' found his place in DIFFUSION_AD_REQUIRED_HPARAMS.
- added default V_MIN_MAX values (tuple).
- added a CATEGORY_TO_V_MIN_MAX dict that works the same as CATEGORY_TO_TIMESTEPS.